### PR TITLE
Move Husky to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,9 +20,6 @@
     "url": "https://github.com/emmettmoore/node-monorepo/issues"
   },
   "homepage": "https://github.com/emmettmoore/node-monorepo#readme",
-  "dependencies": {
-    "husky": "^8.0.2"
-  },
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^5.43.0",
     "eslint": "^8.28.0",
@@ -32,6 +29,7 @@
     "eslint-plugin-import": "^2.26.0",
     "eslint-plugin-react": "^7.31.11",
     "eslint-plugin-react-hooks": "^4.6.0",
+    "husky": "^8.0.2",
     "lint-staged": "^13.0.3",
     "prettier": "^2.7.1",
     "ts-node": "^10.9.1",


### PR DESCRIPTION
## The Problem

I'm trying to deploy on vercel and it keeps getting this error:

```


Expand 11 Lines
--
19:36:27.403 | sh: husky: command not found
19:36:27.407 | npm ERR! code 127
19:36:27.408 | npm ERR! path /vercel/path0
19:36:27.410 | npm ERR! command failed
19:36:27.410 | npm ERR! command sh -c husky install
19:36:27.411 |  
19:36:27.412 | npm ERR! A complete log of this run can be found in:
19:36:27.412 | npm ERR!     /vercel/.npm/_logs/2023-08-26T23_36_06_894Z-debug-0.log
19:36:27.448 | Error: Command "npm install" exited with 127
```

There's some funkiness i haven't gotten to the bottom of yet that has to do with vercel deployment but this issue seems to just be as simple as npm run prepare being automatically invoked when `npm install` is run, and `husky is a dev dependency instead of dependency.

## The Solution

Remove it from the `npm run prepare` - this is a dev setup process and has nothing to do with a production deployment.