### PR TITLE
Explicitly set border radius on hover for UnderlineButton

### DIFF
--- a/@emmettmoore/site/src/components/UnderlineButton/UnderlineButton.module.scss
+++ b/@emmettmoore/site/src/components/UnderlineButton/UnderlineButton.module.scss
@@ -6,5 +6,6 @@
   border-bottom: 2px solid colors.$primaryBlueMain;
   &:hover {
     border-bottom: 2px solid colors.$secondaryOrangeMain;
+    border-radius: 0;
   }
 }


### PR DESCRIPTION
## Problem
For some reason the border radius on the UnderlineButton hover property in the production build is not being applied even though it's being applied in dev builds.

<details><summary>Production</summary>
<img width="286" alt="Screen Shot 2023-09-16 at 10 28 09 AM" src="https://github.com/emmettmoore/node-monorepo/assets/6088942/437b2cad-37ce-431d-b2bd-1e0752735632">
</details>

<details><summary>Development</summary>
<img width="322" alt="image" src="https://github.com/emmettmoore/node-monorepo/assets/6088942/b7bae201-d6a1-44f4-a1a7-ee9efec0fb1f">
</details>


## Solution
 This is likely due to some issue in our module css loader that I should look into. in the meantime i'm just going to explicitly apply the style on hover.
