### PR TITLE
Update References to repo project name

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# node-monorepo
+# projects
 
 ## Version
 

--- a/package.json
+++ b/package.json
@@ -12,14 +12,14 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/emmettmoore/node-monorepo.git"
+    "url": "git+https://github.com/emmettmoore/projects.git"
   },
   "author": "",
   "license": "",
   "bugs": {
-    "url": "https://github.com/emmettmoore/node-monorepo/issues"
+    "url": "https://github.com/emmettmoore/projects/issues"
   },
-  "homepage": "https://github.com/emmettmoore/node-monorepo#readme",
+  "homepage": "https://github.com/emmettmoore/projects#readme",
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^5.43.0",
     "eslint": "^8.28.0",

--- a/shell-scripts/README.md
+++ b/shell-scripts/README.md
@@ -26,9 +26,9 @@ To use, run `mono`, `aoc`, `app`, or any other environment configured in `env_fu
 
 ```sh
 ➜  ~ mono
-Now using ~/.env-node-monorepo
+Now using ~/.env-projects
 Now using node v20.0.0 (npm v9.6.4)
-➜  node-monorepo git:(emmmett/next-app) ✗ aoc
+➜  projects git:(emmmett/next-app) ✗ aoc
 ```
 
 ### `new_component.sh`

--- a/shell-scripts/env_functions.sh
+++ b/shell-scripts/env_functions.sh
@@ -1,6 +1,6 @@
-funtion init_node_monorepo_env() {
-  echo "Now using ~/.env-node-monorepo"
-  source ~/.env-node-monorepo
+funtion init_projects_env() {
+  echo "Now using ~/.env-projects"
+  source ~/.env-projects
   nvm use v20.0.0
 }
 
@@ -13,44 +13,44 @@ funtion init_node_monorepo_env() {
 #    /gh-repo-2       <---- GH repo
 #    /etc
 
-function mono() {
+function pjs() {
   should_update=false
 
-  if [[ $PWD/ != ~/gh-repos/node-monorepo/* ]]; then
+  if [[ $PWD/ != ~/gh-repos/projects/* ]]; then
     should_update=true
   fi
 
-  cd ~/gh-repos/node-monorepo
+  cd ~/gh-repos/projects
 
   if [ "$should_update" = true ] ; then
-    init_node_monorepo_env
+    init_projects_env
   fi
 }
 
 function aoc() {
   should_update=false
 
-  if [[ $PWD/ != ~/gh-repos/node-monorepo/* ]]; then
+  if [[ $PWD/ != ~/gh-repos/projects/* ]]; then
     should_update=true
   fi
 
-  cd ~/gh-repos/node-monorepo/@emmettmoore/advent-of-code
+  cd ~/gh-repos/projects/@emmettmoore/advent-of-code
 
   if [ "$should_update" = true ] ; then
-    init_node_monorepo_env
+    init_projects_env
   fi
 }
 
-function app() {
+function site() {
   should_update=false
 
-  if [[ $PWD/ != ~/gh-repos/node-monorepo/* ]]; then
+  if [[ $PWD/ != ~/gh-repos/projects/* ]]; then
     should_update=true
   fi
 
-  cd ~/gh-repos/node-monorepo/@emmettmoore/app
+  cd ~/gh-repos/projects/@emmettmoore/site
 
   if [ "$should_update" = true ] ; then
-    init_node_monorepo_env
+    init_projects_env
   fi
 }

--- a/shell-scripts/env_startup.sh
+++ b/shell-scripts/env_startup.sh
@@ -1,4 +1,4 @@
 case $PWD/ in 
    # init env if shell starts in repo dir
-   ~/gh-repos/node-monorepo/*) init_node_monorepo_env;;
+   ~/gh-repos/projects/*) init_projects_env;;
 esac


### PR DESCRIPTION
I decided to name this repo "projects" because I found "node-monorepo" to be a little clunky. It also narrowed the scope of this repo to node-only projects, which I don't necessarily think is appropriate. 

This commit just updates references to "node-monorepo" to "projects" so that it is no longer mentioned in here.