### PR TITLE
Fix Component Demo Page

### DIFF
--- a/@emmettmoore/site/src/containers/ComponentDemo/ComponentDemo.tsx
+++ b/@emmettmoore/site/src/containers/ComponentDemo/ComponentDemo.tsx
@@ -1,6 +1,5 @@
 /* eslint-disable filenames/match-exported */
-import { Typography } from '@mui/material';
-import PageContainer from '@site/components/PageContainer';
+import { Container, Typography } from '@mui/material';
 import HtmlHead from '@site/components/HtmlHead';
 import PageContent from '@site/components/PageContent';
 import SitePage from '@site/components/SitePage';
@@ -12,7 +11,7 @@ const ComponentDemo = (): JSX.Element => {
     <>
       <HtmlHead description="MUI component demo" title="Component Demo" />
       <SitePage>
-        <PageContainer>
+        <Container>
           <PageContent>
             <div className={styles.componentDemo}>
               <Typography component="div" variant="h1">
@@ -62,7 +61,7 @@ const ComponentDemo = (): JSX.Element => {
               </Typography>
             </div>
           </PageContent>
-        </PageContainer>
+        </Container>
       </SitePage>
     </>
   );


### PR DESCRIPTION
In 0d93673168a310d36bcd1ae512d2b5c6974825fe I removed the PageContainer component, but I forgot to remove the usage of PageContainer on the Component Demo page. This commit updates the ComponentDemo page to no longer use that component so it's now fully deprecated in this project.